### PR TITLE
Booth Sale Bugs & Inventory Check Bug (#247)

### DIFF
--- a/components/booths/BoothSaleRecordDialog.vue
+++ b/components/booths/BoothSaleRecordDialog.vue
@@ -16,6 +16,36 @@
       0,
     );
   });
+
+  // Watch boothsStore.computedTotalCashReceiptsActiveSale to update cashReceiptsActiveSale when not entering breakdown
+  watch(
+    () => boothsStore.computedTotalCashReceiptsActiveSale,
+    (newVal) => {
+      boothsStore.cashReceiptsActiveSale =
+        boothsStore.computedTotalCashReceiptsActiveSale;
+    },
+  );
+
+  watch(
+    () => boothsStore.cashReceiptsActiveSale,
+    (newVal, oldVal) => {
+      if (enterCashBreakdown.value === false && newVal !== oldVal) {
+        //sync cashbreakdown with ones and cents to equal cashReceiptsActiveSale
+        const totalCents = Math.round(newVal * 100);
+        const ones = Math.floor(totalCents / 100);
+        const cents = (totalCents - ones * 100) / 100; // remainder of cents after removing ones in fractions of a dollar
+        boothsStore.cashBreakdownActiveSale = {
+          ones: ones,
+          fives: 0,
+          tens: 0,
+          twenties: 0,
+          fifties: 0,
+          hundreds: 0,
+          cents: cents,
+        };
+      }
+    },
+  );
 </script>
 <template>
   <Dialog
@@ -75,6 +105,7 @@
               "
               v-model="slotProps.data.data.remaining"
               :min="0"
+              :max="slotProps.data.data.predicted"
               @update:model-value="
                 (val) =>
                   boothsStore.updateSalesRecordRemaining(
@@ -97,6 +128,7 @@
               "
               v-model="slotProps.data.data.sales"
               :min="0"
+              :max="slotProps.data.data.predicted"
               @update:model-value="
                 (val) =>
                   boothsStore.updateSalesRecordSales(
@@ -145,7 +177,7 @@
                 <label for="ones" class="text-sm mb-1">$1</label>
                 <InputNumber
                   id="ones"
-                  v-model="boothsStore.cashBreakdown.ones"
+                  v-model="boothsStore.cashBreakdownActiveSale.ones"
                   :min="0"
                   :use-grouping="false"
                   input-class="w-full"
@@ -156,7 +188,7 @@
                 <label for="fives" class="text-sm mb-1">$5</label>
                 <InputNumber
                   id="fives"
-                  v-model="boothsStore.cashBreakdown.fives"
+                  v-model="boothsStore.cashBreakdownActiveSale.fives"
                   :min="0"
                   :use-grouping="false"
                   input-class="w-full"
@@ -167,7 +199,7 @@
                 <label for="tens" class="text-sm mb-1">$10</label>
                 <InputNumber
                   id="tens"
-                  v-model="boothsStore.cashBreakdown.tens"
+                  v-model="boothsStore.cashBreakdownActiveSale.tens"
                   :min="0"
                   :use-grouping="false"
                   input-class="w-full"
@@ -178,7 +210,7 @@
                 <label for="twenties" class="text-sm mb-1">$20</label>
                 <InputNumber
                   id="twenties"
-                  v-model="boothsStore.cashBreakdown.twenties"
+                  v-model="boothsStore.cashBreakdownActiveSale.twenties"
                   :min="0"
                   :use-grouping="false"
                   input-class="w-full"
@@ -189,7 +221,7 @@
                 <label for="fifties" class="text-sm mb-1">$50</label>
                 <InputNumber
                   id="fifties"
-                  v-model="boothsStore.cashBreakdown.fifties"
+                  v-model="boothsStore.cashBreakdownActiveSale.fifties"
                   :min="0"
                   :use-grouping="false"
                   input-class="w-full"
@@ -200,7 +232,7 @@
                 <label for="hundreds" class="text-sm mb-1">$100</label>
                 <InputNumber
                   id="hundreds"
-                  v-model="boothsStore.cashBreakdown.hundreds"
+                  v-model="boothsStore.cashBreakdownActiveSale.hundreds"
                   :min="0"
                   :use-grouping="false"
                   input-class="w-full"
@@ -211,7 +243,7 @@
                 <label for="cents" class="text-sm mb-1">Cents</label>
                 <InputNumber
                   id="cents"
-                  v-model="boothsStore.cashBreakdown.cents"
+                  v-model="boothsStore.cashBreakdownActiveSale.cents"
                   :min="0"
                   :max-fraction-digits="2"
                   :use-grouping="false"
@@ -227,7 +259,7 @@
             <InputNumber
               v-if="!enterCashBreakdown"
               id="cash-receipts"
-              v-model="boothsStore.totalCashReceipts"
+              v-model="boothsStore.cashReceiptsActiveSale"
               style="width: 100px"
               :min="0"
               :max-fraction-digits="2"
@@ -238,14 +270,16 @@
               placeholder="0.00"
             />
             <span v-else>
-              {{ formatCurrency(boothsStore.totalCashReceipts) }}
+              {{
+                formatCurrency(boothsStore.computedTotalCashReceiptsActiveSale)
+              }}
             </span>
           </div>
           <div class="flex justify-between items-center">
             <span class="font-semibold">Credit Receipts</span>
             <InputNumber
               id="credit-receipts"
-              v-model="boothsStore.creditReceipts"
+              v-model="boothsStore.creditReceiptsActiveSale"
               style="width: 100px"
               :min="0"
               :max-fraction-digits="2"
@@ -260,7 +294,7 @@
             <span class="font-semibold">Other Receipts</span>
             <InputNumber
               id="other-receipts"
-              v-model="boothsStore.otherReceipts"
+              v-model="boothsStore.otherReceiptsActiveSale"
               style="width: 100px"
               :min="0"
               :max-fraction-digits="2"
@@ -284,9 +318,9 @@
             <span>
               {{
                 formatCurrency(
-                  boothsStore.totalCashReceipts +
-                    boothsStore.creditReceipts +
-                    boothsStore.otherReceipts,
+                  boothsStore.cashReceiptsActiveSale +
+                    boothsStore.creditReceiptsActiveSale +
+                    boothsStore.otherReceiptsActiveSale,
                 )
               }}
             </span>
@@ -298,9 +332,9 @@
               {{
                 formatCurrency(
                   totalSales -
-                    boothsStore.totalCashReceipts -
-                    boothsStore.creditReceipts -
-                    boothsStore.otherReceipts,
+                    boothsStore.cashReceiptsActiveSale -
+                    boothsStore.creditReceiptsActiveSale -
+                    boothsStore.otherReceiptsActiveSale,
                 )
               }}
             </span>

--- a/pages/bank-deposits.vue
+++ b/pages/bank-deposits.vue
@@ -3,8 +3,8 @@
 
   const depositsStore = useDepositsStore();
   const accountsStore = useAccountsStore();
-  const transactionsStore = useTransactionsStore();
   const cookiesStore = useCookiesStore();
+  const boothsStore = useBoothsStore();
   const notificationHelpers = useNotificationHelpers();
 
   const dt = ref();
@@ -12,9 +12,12 @@
 
   // Calculate total cash/checks collected (excluding Digital Cookie payments)
   const totalCashChecks = computed(() => {
-    return accountsStore.allPayments
-      .filter((p) => p.type !== 'digital_cookie')
-      .reduce((sum, payment) => sum + payment.amount, 0);
+    return (
+      accountsStore.allPayments
+        .filter((p) => p.type !== 'digital_cookie')
+        .reduce((sum, payment) => sum + payment.amount, 0) +
+      boothsStore.cashReceiptsAllBoothSales
+    );
   });
 
   // Calculate difference between cash/checks and total deposits

--- a/pages/physical-inventory-check.vue
+++ b/pages/physical-inventory-check.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import type { InventoryCheck } from '@/types/types';
   import NoCookiesOverlay from '~/components/other/NoCookiesOverlay.vue';
+  import type { Json } from '~/types/supabase';
 
   const loading = ref(true);
   loading.value = true;
@@ -86,13 +87,12 @@
     if (editingCheckId.value !== null) {
       return snapshotExpectedInventory.value;
     }
-    return cookiesStore.allCookiesWithInventoryTotals(false).reduce(
-      (acc, item) => {
+    return cookiesStore
+      .allCookiesWithInventoryTotals(false)
+      .reduce((acc, item) => {
         acc[item.abbreviation] = item.onHand || 0;
         return acc;
-      },
-      {} as Record<string, number>,
-    );
+      }, {} as Json);
   });
 
   const cancelCheck = () => {
@@ -119,7 +119,7 @@
 
     const checkData = {
       physical_inventory: physicalInventoryPackages,
-      expected_inventory: expectedInventory,
+      expected_inventory: expectedInventory.value,
       discrepancies,
       total_discrepancies: totalDiscrepancies,
       conducted_by: conductedBy.value,
@@ -290,7 +290,7 @@
       v-model:visible="checkDialogVisible"
       modal
       :style="{ width: '90vw', maxWidth: '800px' }"
-      header="Transaction Details"
+      header="Physical Inventory Check"
       :dismissable-mask="true"
     >
       <div class="space-y-4">

--- a/stores/booths.test.ts
+++ b/stores/booths.test.ts
@@ -870,11 +870,11 @@ describe('useBoothsStore', () => {
     });
 
     beforeEach(() => {
-      boothsStore.cashBreakdown = createEmptyCashBreakdown();
+      boothsStore.cashBreakdownActiveSale = createEmptyCashBreakdown();
     });
 
     it('calculates total cash receipts correctly with bills only', () => {
-      boothsStore.cashBreakdown = {
+      boothsStore.cashBreakdownActiveSale = {
         ones: 5, // $5
         fives: 3, // $15
         tens: 2, // $20
@@ -884,11 +884,11 @@ describe('useBoothsStore', () => {
         cents: 0,
       };
 
-      expect(boothsStore.totalCashReceipts).toBe(210);
+      expect(boothsStore.computedTotalCashReceiptsActiveSale).toBe(210);
     });
 
     it('calculates total cash receipts correctly with coins only', () => {
-      boothsStore.cashBreakdown = {
+      boothsStore.cashBreakdownActiveSale = {
         ones: 0,
         fives: 0,
         tens: 0,
@@ -898,11 +898,11 @@ describe('useBoothsStore', () => {
         cents: 1.75,
       };
 
-      expect(boothsStore.totalCashReceipts).toBe(1.75);
+      expect(boothsStore.computedTotalCashReceiptsActiveSale).toBe(1.75);
     });
 
     it('calculates total cash receipts correctly with bills and coins', () => {
-      boothsStore.cashBreakdown = {
+      boothsStore.cashBreakdownActiveSale = {
         ones: 3, // $3
         fives: 1, // $5
         tens: 2, // $20
@@ -912,11 +912,11 @@ describe('useBoothsStore', () => {
         cents: 0.5,
       };
 
-      expect(boothsStore.totalCashReceipts).toBe(28.5);
+      expect(boothsStore.computedTotalCashReceiptsActiveSale).toBe(28.5);
     });
 
     it('rounds total cash receipts to 2 decimal places', () => {
-      boothsStore.cashBreakdown = {
+      boothsStore.cashBreakdownActiveSale = {
         ones: 0,
         fives: 0,
         tens: 0,
@@ -926,7 +926,7 @@ describe('useBoothsStore', () => {
         cents: 1.999,
       };
 
-      expect(boothsStore.totalCashReceipts).toBe(2);
+      expect(boothsStore.computedTotalCashReceiptsActiveSale).toBe(2);
     });
 
     it('initializes cash breakdown when opening record sales dialog', () => {
@@ -960,11 +960,11 @@ describe('useBoothsStore', () => {
 
       newBoothsStore.openRecordSalesDialog(mockBoothSale);
 
-      expect(newBoothsStore.cashBreakdown.ones).toBe(2);
-      expect(newBoothsStore.cashBreakdown.fives).toBe(1);
-      expect(newBoothsStore.cashBreakdown.tens).toBe(3);
-      expect(newBoothsStore.cashBreakdown.hundreds).toBe(1);
-      expect(newBoothsStore.cashBreakdown.cents).toBe(0.25);
+      expect(newboothsStore.cashBreakdownActiveSale.ones).toBe(2);
+      expect(newboothsStore.cashBreakdownActiveSale.fives).toBe(1);
+      expect(newboothsStore.cashBreakdownActiveSale.tens).toBe(3);
+      expect(newboothsStore.cashBreakdownActiveSale.hundreds).toBe(1);
+      expect(newboothsStore.cashBreakdownActiveSale.cents).toBe(0.25);
     });
 
     it('resets cash breakdown to zero when booth sale has no cash_breakdown', () => {
@@ -979,7 +979,7 @@ describe('useBoothsStore', () => {
       const newBoothsStore = useBoothsStore();
 
       // First set some values
-      newBoothsStore.cashBreakdown = {
+      newboothsStore.cashBreakdownActiveSale = {
         ones: 5,
         fives: 3,
         tens: 2,
@@ -1000,13 +1000,13 @@ describe('useBoothsStore', () => {
 
       newBoothsStore.openRecordSalesDialog(mockBoothSale);
 
-      expect(newBoothsStore.cashBreakdown.ones).toBe(0);
-      expect(newBoothsStore.cashBreakdown.fives).toBe(0);
-      expect(newBoothsStore.cashBreakdown.tens).toBe(0);
-      expect(newBoothsStore.cashBreakdown.twenties).toBe(0);
-      expect(newBoothsStore.cashBreakdown.fifties).toBe(0);
-      expect(newBoothsStore.cashBreakdown.hundreds).toBe(0);
-      expect(newBoothsStore.cashBreakdown.cents).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.ones).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.fives).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.tens).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.twenties).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.fifties).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.hundreds).toBe(0);
+      expect(newboothsStore.cashBreakdownActiveSale.cents).toBe(0);
     });
 
     it('saves cash receipts data when recording sales', async () => {
@@ -1049,7 +1049,7 @@ describe('useBoothsStore', () => {
 
       // Open dialog and set cash breakdown
       newBoothsStore.openRecordSalesDialog(mockBoothSale);
-      newBoothsStore.cashBreakdown = {
+      newboothsStore.cashBreakdownActiveSale = {
         ones: 10,
         fives: 5,
         tens: 3,
@@ -1075,7 +1075,7 @@ describe('useBoothsStore', () => {
     });
 
     it('resets cash breakdown when closing record sales dialog', () => {
-      boothsStore.cashBreakdown = {
+      boothsStore.cashBreakdownActiveSale = {
         ones: 5,
         fives: 3,
         tens: 2,
@@ -1087,13 +1087,13 @@ describe('useBoothsStore', () => {
 
       boothsStore.closeRecordSalesDialog();
 
-      expect(boothsStore.cashBreakdown.ones).toBe(0);
-      expect(boothsStore.cashBreakdown.fives).toBe(0);
-      expect(boothsStore.cashBreakdown.tens).toBe(0);
-      expect(boothsStore.cashBreakdown.twenties).toBe(0);
-      expect(boothsStore.cashBreakdown.fifties).toBe(0);
-      expect(boothsStore.cashBreakdown.hundreds).toBe(0);
-      expect(boothsStore.cashBreakdown.cents).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.ones).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.fives).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.tens).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.twenties).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.fifties).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.hundreds).toBe(0);
+      expect(boothsStore.cashBreakdownActiveSale.cents).toBe(0);
     });
   });
 });


### PR DESCRIPTION
* Bug physical inventory (#241)

* Cannot sell more than you brought to a booth sale (#242)

* Bug booth sale record (#245)

* Bank deposits includes booth cash receipts; Entering cash receipts directly saves (#243)