### PR TITLE
Don't count cash recorded in scout inventory booth sales in To Deposi…

### DIFF
--- a/stores/booths.ts
+++ b/stores/booths.ts
@@ -69,7 +69,9 @@ export const useBoothsStore = defineStore('booths', () => {
 
   const cashReceiptsAllBoothSales = computed(() => {
     return allBoothSales.value.reduce((total, booth) => {
-      return total + (booth.cash_receipts || 0);
+      const cashReceipts =
+        booth.inventory_type != 'scout' ? booth.cash_receipts || 0 : 0;
+      return total + cashReceipts;
     }, 0);
   });
 


### PR DESCRIPTION
…t (won't need to be deposited until the scout returns cash to the troop and then it'll be recorded as a regular cash payment)